### PR TITLE
Add configurable cooldown between mined images

### DIFF
--- a/sae_ai_control/config.py
+++ b/sae_ai_control/config.py
@@ -23,6 +23,8 @@ class DetectionSelectorConfig(BaseSettings):
     min_height: float = 0.1
     max_detections: int = 20
     time_past: str = "1d"
+    # Disabled unless configured in settings.yaml or through the environment.
+    cooldown_seconds: int = 0
     
     @classmethod
     def settings_customise_sources(cls, settings_cls, init_settings, env_settings, dotenv_settings, file_secret_settings):

--- a/sae_ai_control/config.py
+++ b/sae_ai_control/config.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from pydantic import BaseModel, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing_extensions import Annotated
@@ -23,8 +25,7 @@ class DetectionSelectorConfig(BaseSettings):
     min_height: float = 0.1
     max_detections: int = 20
     time_past: str = "1d"
-    # Disabled unless configured in settings.yaml or through the environment.
-    cooldown_seconds: int = 0
+    cooldown_seconds: Annotated[Optional[int], Field(ge=0)] = None
     
     @classmethod
     def settings_customise_sources(cls, settings_cls, init_settings, env_settings, dotenv_settings, file_secret_settings):

--- a/sae_ai_control/detectionselector.py
+++ b/sae_ai_control/detectionselector.py
@@ -77,7 +77,7 @@ class DetectionSelector:
 
         timestamp_ms = sae_msg.frame.timestamp_utc_ms
         # Suppressed frames do not restart the cooldown; measure from the last forwarded candidate.
-        if (self.config.cooldown_seconds > 0
+        if (self.config.cooldown_seconds is not None
                 and self.last_selected_timestamp_ms is not None
                 and timestamp_ms - self.last_selected_timestamp_ms < self.config.cooldown_seconds * 1000):
             return None

--- a/sae_ai_control/detectionselector.py
+++ b/sae_ai_control/detectionselector.py
@@ -24,6 +24,7 @@ class DetectionSelector:
     def __init__(self, config: DetectionSelectorConfig) -> None:
         self.config = config
         self.timedelta_timestamp = self._timedelta(config.time_past)
+        self.last_selected_timestamp_ms = None
         logger.setLevel(self.config.log_level.value)
 
     def __call__(self, input_proto) -> Any:
@@ -71,10 +72,18 @@ class DetectionSelector:
                 send_msg = True
             if self._is_time_past():
                 send_msg = True
-        if send_msg:
-            return sae_msg
-        else:
+        if not send_msg:
             return None
+
+        timestamp_ms = sae_msg.frame.timestamp_utc_ms
+        # Suppressed frames do not restart the cooldown; measure from the last forwarded candidate.
+        if (self.config.cooldown_seconds > 0
+                and self.last_selected_timestamp_ms is not None
+                and timestamp_ms - self.last_selected_timestamp_ms < self.config.cooldown_seconds * 1000):
+            return None
+
+        self.last_selected_timestamp_ms = timestamp_ms
+        return sae_msg
 
     def _is_time_past(self) -> bool:
         if self.timedelta_timestamp is not None:

--- a/settings.template.yaml
+++ b/settings.template.yaml
@@ -11,3 +11,4 @@ min_width: 0.001 # minimum bounding box width below which a message is sent
 min_height: 0.001 # minimum bounding boxheight below which a message is sent
 max_detections: 20 # maximum number of detections in a message above which a message is sent
 time_past: 1d # e.g. 1d, 5h, 10m, 30s time interval after which a message is sent even if no other criteria are met
+cooldown_seconds: 5 # minimum seconds between mined images

--- a/settings.template.yaml
+++ b/settings.template.yaml
@@ -11,4 +11,4 @@ min_width: 0.001 # minimum bounding box width below which a message is sent
 min_height: 0.001 # minimum bounding boxheight below which a message is sent
 max_detections: 20 # maximum number of detections in a message above which a message is sent
 time_past: 1d # e.g. 1d, 5h, 10m, 30s time interval after which a message is sent even if no other criteria are met
-cooldown_seconds: 5 # minimum seconds between mined images
+cooldown_seconds: 5 # minimum seconds between mined images; leave unset to disable

--- a/tests/test_detectionselector.py
+++ b/tests/test_detectionselector.py
@@ -30,10 +30,10 @@ def selector(config):
     sel._is_time_past = MagicMock(return_value=False)
     return sel
 
-def make_msg(detections, timestamp=None):
+def make_msg(detections, timestamp=1_000):
     msg = MagicMock()
     msg.detections = detections
-    msg.timestamp = timestamp
+    msg.frame.timestamp_utc_ms = timestamp
     return msg
 
 def test_filter_message_confidence_below_min(selector):
@@ -90,3 +90,18 @@ def test_filter_message_all_ok(selector):
     msg = make_msg([detection])
     result = selector._filter_message(msg)
     assert result is None
+
+def test_filter_message_applies_cooldown(config):
+    config.cooldown_seconds = 10
+    selector = DetectionSelector(config)
+    selector._is_time_past = MagicMock(return_value=False)
+    detection = DummyDetection(confidence=0.4, min_x=0, max_x=20, min_y=0, max_y=20)
+
+    first = make_msg([detection], timestamp=1_000)
+    during_cooldown = make_msg([detection], timestamp=10_999)
+    after_cooldown = make_msg([detection], timestamp=11_000)
+
+    assert selector._filter_message(first) == first
+    assert selector._filter_message(during_cooldown) is None
+    # The rejected frame did not restart the cooldown, so the boundary passes.
+    assert selector._filter_message(after_cooldown) == after_cooldown


### PR DESCRIPTION
[AB#2311](https://dev.azure.com/starwit/4669e325-4201-4d54-8178-3ac3dbf09f75/_workitems/edit/2311)

## What

Adds a configurable `cooldown_seconds` interval to the detection selector.

After a frame passes the existing mining filters, it is forwarded only if the
configured interval has elapsed since the last forwarded frame.

## Configuration

The cooldown has to be added to the AI Control settings in the SAE Helm
deployment:

```yaml
aiControl:
  settingsYaml:
    cooldown_seconds: 5
```

I recommend starting with `5` seconds. Without this configuration, the
cooldown defaults to `0` and is disabled.

## Why

AI Cockpit mining can produce bursts of nearly identical frames. These frames
are unwanted during review, especially when images are sent directly from
Cockpit to CVAT, and are generally not needed for training.

This is a first, simple change to reduce near-duplicate images while keeping
the implementation and runtime state minimal.