### PR TITLE
Route Waste Mining candidates by reason

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ This template employs pydantic-settings for configuration handling. On startup, 
 
 The `settings.template.yaml` should always reflect a correct and fully fledged settings structure to use as a starting point for users. 
 
+## Output streams
+
+Selected messages are published to the configured stream ID with a `_low_confidence`, `_small_object`, or `_many_objects` suffix identifying the matching heuristic. Periodic selections keep the base stream ID.
+
 ## Github Workflows and Versioning
 
 The following Github Actions are available:

--- a/sae_ai_control/detectionselector.py
+++ b/sae_ai_control/detectionselector.py
@@ -36,11 +36,11 @@ class DetectionSelector:
 
         # Your implementation goes (mostly) here
         logger.debug('Received SAE message from pipeline')
-        sae_msg = self._filter_message(sae_msg)
+        sae_msg, reason = self._filter_message(sae_msg)
         if sae_msg is None:
-            return None
+            return None, None
         else:
-            return self._pack_proto(sae_msg)
+            return self._pack_proto(sae_msg), reason
         
     @PROTO_DESERIALIZATION_DURATION.time()
     def _unpack_proto(self, sae_message_bytes):
@@ -54,36 +54,34 @@ class DetectionSelector:
         return sae_msg.SerializeToString()
     
     def _filter_message(self, sae_msg: SaeMessage):
-        send_msg: bool = False
-        if (sae_msg.detections is not None and len(sae_msg.detections) > 0):
-            for detection in sae_msg.detections:
-                if detection.confidence < self.config.min_confidence:
-                    send_msg = True
-                    break
-                width = detection.bounding_box.max_x - detection.bounding_box.min_x
-                height = detection.bounding_box.max_y - detection.bounding_box.min_y
-                if width < self.config.min_width:
-                    send_msg = True
-                    break
-                if height < self.config.min_height:
-                    send_msg = True
-                    break
-            if (sae_msg.detections is not None and len(sae_msg.detections) > self.config.max_detections):
-                send_msg = True
-            if self._is_time_past():
-                send_msg = True
-        if not send_msg:
-            return None
+        if sae_msg.detections is None or len(sae_msg.detections) == 0:
+            return None, None
+
+        reason = None
+        for detection in sae_msg.detections:
+            if detection.confidence < self.config.min_confidence:
+                reason = "low_confidence"
+                break
+            width = detection.bounding_box.max_x - detection.bounding_box.min_x
+            height = detection.bounding_box.max_y - detection.bounding_box.min_y
+            if width < self.config.min_width or height < self.config.min_height:
+                reason = "small_object"
+                break
+        if reason is None and len(sae_msg.detections) > self.config.max_detections:
+            reason = "many_objects"
+        time_past = self._is_time_past()
+        if reason is None and not time_past:
+            return None, None
 
         timestamp_ms = sae_msg.frame.timestamp_utc_ms
         # Suppressed frames do not restart the cooldown; measure from the last forwarded candidate.
         if (self.config.cooldown_seconds is not None
                 and self.last_selected_timestamp_ms is not None
                 and timestamp_ms - self.last_selected_timestamp_ms < self.config.cooldown_seconds * 1000):
-            return None
+            return None, None
 
         self.last_selected_timestamp_ms = timestamp_ms
-        return sae_msg
+        return sae_msg, reason
 
     def _is_time_past(self) -> bool:
         if self.timedelta_timestamp is not None:

--- a/sae_ai_control/stage.py
+++ b/sae_ai_control/stage.py
@@ -57,11 +57,11 @@ def run_stage():
 
             FRAME_COUNTER.inc()
 
-            output_proto_data = detection_selector.get(proto_data)
+            output_proto_data, reason = detection_selector.get(proto_data)
 
             if output_proto_data is None:
                 continue
-            
+
+            output_stream_id = f'{stream_id}_{reason}' if reason else stream_id
             with REDIS_PUBLISH_DURATION.time():
-                publish(f'{CONFIG.redis.output_stream_prefix}:{stream_id}', output_proto_data)
-            
+                publish(f'{CONFIG.redis.output_stream_prefix}:{output_stream_id}', output_proto_data)

--- a/tests/test_detectionselector.py
+++ b/tests/test_detectionselector.py
@@ -40,56 +40,59 @@ def test_filter_message_confidence_below_min(selector):
     detection = DummyDetection(confidence=0.4, min_x=0, max_x=20, min_y=0, max_y=20)
     msg = make_msg([detection])
     result = selector._filter_message(msg)
-    assert result == msg
+    assert result == (msg, "low_confidence")
     
     detection = DummyDetection(confidence=0.6, min_x=0, max_x=20, min_y=0, max_y=20)
     msg = make_msg([detection])
     result = selector._filter_message(msg)
-    assert result is None
+    assert result == (None, None)
 
 def test_filter_message_width_below_min(selector):
     detection = DummyDetection(confidence=0.6, min_x=0, max_x=9, min_y=0, max_y=20)
     msg = make_msg([detection])
     result = selector._filter_message(msg)
-    assert result == msg
+    assert result == (msg, "small_object")
     
     detection = DummyDetection(confidence=0.6, min_x=0, max_x=10, min_y=0, max_y=20)
     msg = make_msg([detection])
     result = selector._filter_message(msg)
-    assert result is None
+    assert result == (None, None)
 
 def test_filter_message_height_below_min(selector):
     detection = DummyDetection(confidence=0.6, min_x=0, max_x=20, min_y=0, max_y=9)
     msg = make_msg([detection])
     result = selector._filter_message(msg)
-    assert result == msg 
+    assert result == (msg, "small_object")
         
     detection = DummyDetection(confidence=0.6, min_x=0, max_x=20, min_y=0, max_y=10)
     msg = make_msg([detection])
     result = selector._filter_message(msg)
-    assert result is None
+    assert result == (None, None)
 
 
 def test_filter_message_too_many_detections(selector):
     detections = [DummyDetection(0.6, 0, 20, 0, 20) for _ in range(5)]
     msg = make_msg(detections)
     result = selector._filter_message(msg)
-    assert result == msg
+    assert result == (msg, "many_objects")
     detections = [DummyDetection(0.6, 0, 20, 0, 20) for _ in range(4)]
     msg = make_msg(detections)
     result = selector._filter_message(msg)
-    assert result is None
+    assert result == (None, None)
     
 def test_filter_message_none_triggers(selector):
     msg = make_msg([])
     result = selector._filter_message(msg)
-    assert result is None
+    assert result == (None, None)
 
 def test_filter_message_all_ok(selector):
     detection = DummyDetection(confidence=0.6, min_x=0, max_x=20, min_y=0, max_y=20)
     msg = make_msg([detection])
     result = selector._filter_message(msg)
-    assert result is None
+    assert result == (None, None)
+
+    selector._is_time_past.return_value = True
+    assert selector._filter_message(msg) == (msg, None)
 
 def test_filter_message_applies_cooldown(config):
     config.cooldown_seconds = 10
@@ -101,7 +104,7 @@ def test_filter_message_applies_cooldown(config):
     during_cooldown = make_msg([detection], timestamp=10_999)
     after_cooldown = make_msg([detection], timestamp=11_000)
 
-    assert selector._filter_message(first) == first
-    assert selector._filter_message(during_cooldown) is None
+    assert selector._filter_message(first) == (first, "low_confidence")
+    assert selector._filter_message(during_cooldown) == (None, None)
     # The rejected frame did not restart the cooldown, so the boundary passes.
-    assert selector._filter_message(after_cooldown) == after_cooldown
+    assert selector._filter_message(after_cooldown) == (after_cooldown, "low_confidence")


### PR DESCRIPTION
# Route Waste Mining candidates by reason

## What changed

- Publishes selected messages to `_low_confidence`, `_small_object`, or `_many_objects` streams according to the selection reason.
- Keeps periodic selections on the base stream.
- Leaves the existing selection order, thresholds, boundaries, and cooldown behavior unchanged.

## Why

The connector uses the stream name to choose the correct Cockpit decision type. The SAE message itself stays unchanged.

## Before deployment

- Configure the downstream connector to subscribe to the base stream and all three suffixed streams for each source.
